### PR TITLE
Fix inherited attributes in object class parser

### DIFF
--- a/src/main/java/org/see/skf/runtime/AbstractModelParser.java
+++ b/src/main/java/org/see/skf/runtime/AbstractModelParser.java
@@ -112,6 +112,15 @@ public abstract class AbstractModelParser {
         // Fields have 3 KEY features: FOM name (attribute/parameter), and a Coder.
         // Access level can vary because objects have them at the attribute level, whereas interactions have them at
         // the class level. This functionality is implemented by the subclasses respectively.
+        Field previousField = fomElementNameToField.get(fomName);
+        if (previousField != null) {
+            fields.remove(previousField);
+            fieldToFomElementName.remove(previousField);
+            fieldToCoder.remove(previousField);
+            fieldToGetter.remove(previousField);
+            fieldToSetter.remove(previousField);
+        }
+
         this.fields.add(field);
         this.fomElementNameToField.put(fomName, field);
         this.fieldToFomElementName.put(field, fomName);

--- a/src/main/java/org/see/skf/runtime/objects/ObjectClassModelParser.java
+++ b/src/main/java/org/see/skf/runtime/objects/ObjectClassModelParser.java
@@ -39,8 +39,10 @@ import org.see.skf.runtime.ScopeLevel;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -59,20 +61,34 @@ public final class ObjectClassModelParser extends AbstractModelParser {
         this.publishableAttributeNames = new HashSet<>();
         this.subscribableAttributeNames = new HashSet<>();
 
-        Field[] classFields = getFomClass().getDeclaredFields();
-        for (Field field : classFields) {
-            if (field.isAnnotationPresent(Attribute.class)) {
-                Attribute attribute = field.getAnnotation(Attribute.class);
-                String attributeName = attribute.name();
-                Class<? extends Coder<?>> coderClass = attribute.coder();
-                ScopeLevel scopeLevel = attribute.scope();
+        for (Class<?> modelClass : getModelHierarchy()) {
+            Field[] classFields = modelClass.getDeclaredFields();
+            for (Field field : classFields) {
+                if (field.isAnnotationPresent(Attribute.class)) {
+                    Attribute attribute = field.getAnnotation(Attribute.class);
+                    String attributeName = attribute.name();
+                    Class<? extends Coder<?>> coderClass = attribute.coder();
+                    ScopeLevel scopeLevel = attribute.scope();
 
-                addField(attributeName, field, coderClass);
-                setAttributeAccessLevel(attributeName, scopeLevel);
+                    addField(attributeName, field, coderClass);
+                    setAttributeAccessLevel(attributeName, scopeLevel);
+                }
             }
         }
 
         logger.debug("Generated model class structure for the HLA object class <{}>.", objectClass.name());
+    }
+
+    private List<Class<?>> getModelHierarchy() {
+        List<Class<?>> hierarchy = new ArrayList<>();
+        Class<?> modelClass = getFomClass();
+
+        while (modelClass != null && modelClass != Object.class) {
+            hierarchy.add(0, modelClass);
+            modelClass = modelClass.getSuperclass();
+        }
+
+        return hierarchy;
     }
 
     @Override
@@ -142,6 +158,9 @@ public final class ObjectClassModelParser extends AbstractModelParser {
     }
 
     private void setAttributeAccessLevel(String attributeName, ScopeLevel scopeLevel) {
+        publishableAttributeNames.remove(attributeName);
+        subscribableAttributeNames.remove(attributeName);
+
         if (scopeLevel == ScopeLevel.PUBLISH_SUBSCRIBE) {
             publishableAttributeNames.add(attributeName);
             subscribableAttributeNames.add(attributeName);

--- a/src/test/java/org/see/skf/runtime/ObjectClassModelParserTest.java
+++ b/src/test/java/org/see/skf/runtime/ObjectClassModelParserTest.java
@@ -1,13 +1,20 @@
 package org.see.skf.runtime;
 
 import org.junit.jupiter.api.Test;
+import org.see.skf.annotations.Attribute;
+import org.see.skf.annotations.ObjectClass;
 import org.see.skf.util.models.ExecutionConfiguration;
+import org.see.skf.util.encoding.HLAfloat64LECoder;
+import org.see.skf.util.encoding.HLAunicodeStringCoder;
 import org.see.skf.runtime.objects.ObjectClassModelParser;
 
 import java.lang.reflect.Field;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ObjectClassModelParserTest {
     final ObjectClassModelParser parser = new ObjectClassModelParser(ExecutionConfiguration.class);
@@ -49,5 +56,109 @@ class ObjectClassModelParserTest {
         assertEquals("setPositionVector", parser.generateMethodName("set", "positionVector"));
         assertEquals("getPhysicalInterface", parser.generateMethodName("get", "physicalInterface"));
         assertEquals("setPhysicalInterface", parser.generateMethodName("set", "physicalInterface"));
+    }
+
+    @Test
+    void testSubclassInheritsParentAttributes() {
+        ObjectClassModelParser subclassParser = new ObjectClassModelParser(TestChildObject.class);
+
+        Set<String> publishableAttributes = subclassParser.getPublishableAttributeNames();
+        assertTrue(publishableAttributes.contains("parent_name"));
+        assertTrue(publishableAttributes.contains("shared_status"));
+        assertTrue(publishableAttributes.contains("child_mass"));
+        assertFalse(publishableAttributes.contains("parent_subscribe_only"));
+
+        Set<String> subscribableAttributes = subclassParser.getSubscribableAttributeNames();
+        assertTrue(subscribableAttributes.contains("parent_name"));
+        assertTrue(subscribableAttributes.contains("shared_status"));
+        assertTrue(subscribableAttributes.contains("child_mass"));
+        assertTrue(subscribableAttributes.contains("parent_subscribe_only"));
+
+        Field parentName = subclassParser.getFieldForFomElement("parent_name");
+        Field parentState = subclassParser.getFieldForFomElement("shared_status");
+        Field childMass = subclassParser.getFieldForFomElement("child_mass");
+        Field parentSubscribeOnly = subclassParser.getFieldForFomElement("parent_subscribe_only");
+
+        assertNotNull(parentName);
+        assertNotNull(parentState);
+        assertNotNull(childMass);
+        assertNotNull(parentSubscribeOnly);
+
+        assertEquals(TestParentObject.class, parentName.getDeclaringClass());
+        assertEquals(TestChildObject.class, parentState.getDeclaringClass());
+        assertEquals(TestChildObject.class, childMass.getDeclaringClass());
+
+        assertNotNull(subclassParser.getFieldGetter(parentName));
+        assertNotNull(subclassParser.getFieldSetter(parentName));
+        assertNotNull(subclassParser.getFieldGetter(parentState));
+        assertNotNull(subclassParser.getFieldSetter(parentState));
+
+        assertEquals(ScopeLevel.PUBLISH_SUBSCRIBE, subclassParser.getAttributeAccessLevel("parent_name"));
+        assertEquals(ScopeLevel.PUBLISH_SUBSCRIBE, subclassParser.getAttributeAccessLevel("shared_status"));
+        assertEquals(ScopeLevel.PUBLISH_SUBSCRIBE, subclassParser.getAttributeAccessLevel("child_mass"));
+        assertEquals(ScopeLevel.SUBSCRIBE, subclassParser.getAttributeAccessLevel("parent_subscribe_only"));
+    }
+
+    @ObjectClass(name = "HLAobjectRoot.TestParentObject")
+    public static class TestParentObject {
+        @Attribute(name = "parent_name", coder = HLAunicodeStringCoder.class)
+        private String parentName = "";
+
+        @Attribute(name = "shared_status", coder = HLAunicodeStringCoder.class)
+        private String sharedStatus = "";
+
+        @Attribute(name = "parent_subscribe_only", coder = HLAunicodeStringCoder.class, scope = ScopeLevel.SUBSCRIBE)
+        private String parentSubscribeOnly = "";
+
+        public String getParentName() {
+            return parentName;
+        }
+
+        public void setParentName(String parentName) {
+            this.parentName = parentName;
+        }
+
+        public String getSharedStatus() {
+            return sharedStatus;
+        }
+
+        public void setSharedStatus(String sharedStatus) {
+            this.sharedStatus = sharedStatus;
+        }
+
+        public String getParentSubscribeOnly() {
+            return parentSubscribeOnly;
+        }
+
+        public void setParentSubscribeOnly(String parentSubscribeOnly) {
+            this.parentSubscribeOnly = parentSubscribeOnly;
+        }
+    }
+
+    @ObjectClass(name = "HLAobjectRoot.TestParentObject.TestChildObject")
+    public static class TestChildObject extends TestParentObject {
+        @Attribute(name = "shared_status", coder = HLAunicodeStringCoder.class)
+        private String sharedStatus = "";
+
+        @Attribute(name = "child_mass", coder = HLAfloat64LECoder.class)
+        private Double childMass = 0.0;
+
+        @Override
+        public String getSharedStatus() {
+            return sharedStatus;
+        }
+
+        @Override
+        public void setSharedStatus(String sharedStatus) {
+            this.sharedStatus = sharedStatus;
+        }
+
+        public Double getChildMass() {
+            return childMass;
+        }
+
+        public void setChildMass(Double childMass) {
+            this.childMass = childMass;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- walk the Java class hierarchy when parsing object class models so subclasses inherit annotated parent attributes
- make subclass redeclarations replace inherited attribute mappings and publish/subscribe scope cleanly
- add parser tests for inherited attributes and subclass overrides

## Validation
- mvn test
- mvn install -DskipTests
- rebuilt CargoRover against org.see:skf:2.0.3-SNAPSHOT and confirmed inherited PhysicalEntity attributes are exposed from CargoRover