### PR TITLE
Fix inherited attributes in object class parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ __MACOSX/
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# Target build directory
+target/

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.see</groupId>
     <artifactId>skf</artifactId>
-    <version>2.0.3-SNAPSHOT</version>
+    <version>2.0.4-SNAPSHOT</version>
 
     <name>SEE-HLA-Starter-Kit</name>
     <url>https://github.com/SMASH-Lab/SEE-HLA-Starter-Kit</url>

--- a/src/main/java/org/see/skf/core/SKBaseFederate.java
+++ b/src/main/java/org/see/skf/core/SKBaseFederate.java
@@ -153,7 +153,7 @@ public abstract class SKBaseFederate implements SKFederateInterface {
         String errorMessage = "Failed to parse the class <" + targetClass.getName() + "> because it has no object class annotation.";
         ObjectClass annotation = targetClass.getAnnotation(ObjectClass.class);
         if (annotation == null) {
-            annotation = findKnownObjectClassAncestor(targetClass);
+            annotation = locateObjectClassAncestor(targetClass);
 
             if (annotation == null) {
                 throw new IllegalStateException(errorMessage);
@@ -167,7 +167,7 @@ public abstract class SKBaseFederate implements SKFederateInterface {
         String errorMessage = "Failed to parse the class" + targetClass.getName() + "because it has no interaction class annotation.";
         InteractionClass annotation = targetClass.getAnnotation(InteractionClass.class);
         if (annotation == null) {
-            annotation = findInteractionClassAncestor(targetClass);
+            annotation = locateInteractionClassAncestor(targetClass);
 
             if (annotation == null) {
                 throw new IllegalStateException(errorMessage);
@@ -177,7 +177,7 @@ public abstract class SKBaseFederate implements SKFederateInterface {
         return annotation.name();
     }
 
-    private ObjectClass findKnownObjectClassAncestor(Class<?> clazz) {
+    private ObjectClass locateObjectClassAncestor(Class<?> clazz) {
         ObjectClass annotation = null;
 
         while (clazz != null && clazz != Object.class) {
@@ -192,7 +192,7 @@ public abstract class SKBaseFederate implements SKFederateInterface {
         return annotation;
     }
 
-    private InteractionClass findInteractionClassAncestor(Class<?> clazz) {
+    private InteractionClass locateInteractionClassAncestor(Class<?> clazz) {
         InteractionClass annotation = null;
 
         while (clazz != null && clazz != Object.class) {

--- a/src/main/java/org/see/skf/core/SKBaseFederate.java
+++ b/src/main/java/org/see/skf/core/SKBaseFederate.java
@@ -38,7 +38,6 @@ import org.see.skf.runtime.objects.ObjectClassModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.annotation.Annotation;
 import java.util.function.Predicate;
 
 /**
@@ -146,22 +145,71 @@ public abstract class SKBaseFederate implements SKFederateInterface {
         logger.debug("The RTI ambassador has been disconnected from its RTI.");
     }
 
-    /* This method effectively guarantees that an ObjectClass or InteractionClass annotation is present on the superclass
-     * of the supplied class at the bare minimum.
+    /* The following methods effectively guarantee that an ObjectClass or InteractionClass annotation is present on the
+     * supplied class or one of its ancestors at the bare minimum.
      */
-    private void verifyAnnotationExists(Class<?> targetClass, Class<? extends Annotation> annotationClass) {
-        String errorMessage = "Failed to parse the class " + targetClass.getName() + " because it is missing the " + annotationClass.getName() + " annotation.";
-        if (!targetClass.isAnnotationPresent(annotationClass)) {
-            Class<?> superClass = targetClass.getSuperclass();
-            if (!(superClass != null && superClass != Object.class && superClass.isAnnotationPresent(annotationClass))) {
+
+    private String isObjectClass(Class<?> targetClass) {
+        String errorMessage = "Failed to parse the class <" + targetClass.getName() + "> because it has no object class annotation.";
+        ObjectClass annotation = targetClass.getAnnotation(ObjectClass.class);
+        if (annotation == null) {
+            annotation = findKnownObjectClassAncestor(targetClass);
+
+            if (annotation == null) {
                 throw new IllegalStateException(errorMessage);
             }
         }
+
+        return annotation.name();
+    }
+
+    private String isInteractionClass(Class<?> targetClass) {
+        String errorMessage = "Failed to parse the class" + targetClass.getName() + "because it has no interaction class annotation.";
+        InteractionClass annotation = targetClass.getAnnotation(InteractionClass.class);
+        if (annotation == null) {
+            annotation = findInteractionClassAncestor(targetClass);
+
+            if (annotation == null) {
+                throw new IllegalStateException(errorMessage);
+            }
+        }
+
+        return annotation.name();
+    }
+
+    private ObjectClass findKnownObjectClassAncestor(Class<?> clazz) {
+        ObjectClass annotation = null;
+
+        while (clazz != null && clazz != Object.class) {
+            clazz = clazz.getSuperclass();
+            annotation = clazz.getAnnotation(ObjectClass.class);
+
+            if (annotation != null) {
+                break;
+            }
+        }
+
+        return annotation;
+    }
+
+    private InteractionClass findInteractionClassAncestor(Class<?> clazz) {
+        InteractionClass annotation = null;
+
+        while (clazz != null && clazz != Object.class) {
+            clazz = clazz.getSuperclass();
+            annotation = clazz.getAnnotation(InteractionClass.class);
+
+            if (annotation != null) {
+                break;
+            }
+        }
+
+        return annotation;
     }
 
     @Override
     public final void publishObjectClass(Class<?> objectClass) throws FederateNotExecutionMember, NameNotFound, NotConnected, RTIinternalError, InvalidObjectClassHandle, AttributeNotDefined, ObjectClassNotDefined, RestoreInProgress, SaveInProgress {
-        verifyAnnotationExists(objectClass, ObjectClass.class);
+        isObjectClass(objectClass);
 
         Predicate<ObjectClassModel> searchPredicate = model -> model.getObjectClass().equals(objectClass);
         ObjectClassModel objectClassModel = federateAmbassador.queryObjectClassModels(searchPredicate);
@@ -175,7 +223,7 @@ public abstract class SKBaseFederate implements SKFederateInterface {
 
     @Override
     public final void unpublishObjectClass(Class<?> objectClass) throws FederateNotExecutionMember, ObjectClassNotDefined, RestoreInProgress, OwnershipAcquisitionPending, NotConnected, RTIinternalError, SaveInProgress, AttributeNotDefined {
-        verifyAnnotationExists(objectClass, ObjectClass.class);
+        isObjectClass(objectClass);
 
         Predicate<ObjectClassModel> searchPredicate = model -> model.getObjectClass().equals(objectClass);
         ObjectClassModel objectClassModel = federateAmbassador.queryObjectClassModels(searchPredicate);
@@ -190,7 +238,7 @@ public abstract class SKBaseFederate implements SKFederateInterface {
 
     @Override
     public final void subscribeObjectClass(Class<?> objectClass) throws FederateNotExecutionMember, NameNotFound, NotConnected, RTIinternalError, InvalidObjectClassHandle, AttributeNotDefined, ObjectClassNotDefined, RestoreInProgress, SaveInProgress {
-        verifyAnnotationExists(objectClass, ObjectClass.class);
+        isObjectClass(objectClass);
 
         Predicate<ObjectClassModel> searchPredicate = model -> model.getObjectClass().equals(objectClass);
         ObjectClassModel objectClassModel = federateAmbassador.queryObjectClassModels(searchPredicate);
@@ -204,7 +252,7 @@ public abstract class SKBaseFederate implements SKFederateInterface {
 
     @Override
     public final void unsubscribeObjectClass(Class<?> objectClass) throws FederateNotExecutionMember, AttributeNotDefined, ObjectClassNotDefined, RestoreInProgress, NotConnected, RTIinternalError, SaveInProgress {
-        verifyAnnotationExists(objectClass, ObjectClass.class);
+        isObjectClass(objectClass);
 
         Predicate<ObjectClassModel> searchPredicate = model -> model.getObjectClass().equals(objectClass);
         ObjectClassModel objectClassModel = federateAmbassador.queryObjectClassModels(searchPredicate);
@@ -219,7 +267,7 @@ public abstract class SKBaseFederate implements SKFederateInterface {
 
     @Override
     public final void publishInteractionClass(Class<?> interactionClass) throws FederateNotExecutionMember, NameNotFound, NotConnected, RTIinternalError, InvalidInteractionClassHandle, RestoreInProgress, InteractionClassNotDefined, SaveInProgress {
-        verifyAnnotationExists(interactionClass, InteractionClass.class);
+        isInteractionClass(interactionClass);
 
         Predicate<InteractionClassModel> searchPredicate = model -> model.getInteractionClass().equals(interactionClass);
         InteractionClassModel interactionClassModel = federateAmbassador.queryInteractionClassModels(searchPredicate);
@@ -233,7 +281,7 @@ public abstract class SKBaseFederate implements SKFederateInterface {
 
     @Override
     public final void unpublishInteractionClass(Class<?> interactionClass) throws FederateNotExecutionMember, RestoreInProgress, InteractionClassNotDefined, NotConnected, RTIinternalError, SaveInProgress {
-        verifyAnnotationExists(interactionClass, InteractionClass.class);
+        isInteractionClass(interactionClass);
 
         Predicate<InteractionClassModel> searchPredicate = model -> model.getInteractionClass().equals(interactionClass);
         InteractionClassModel interactionClassModel = federateAmbassador.queryInteractionClassModels(searchPredicate);
@@ -247,7 +295,7 @@ public abstract class SKBaseFederate implements SKFederateInterface {
 
     @Override
     public final void subscribeInteractionClass(Class<?> interactionClass) throws FederateNotExecutionMember, NameNotFound, NotConnected, RTIinternalError, InvalidInteractionClassHandle, RestoreInProgress, InteractionClassNotDefined, SaveInProgress, FederateServiceInvocationsAreBeingReportedViaMOM {
-        verifyAnnotationExists(interactionClass, InteractionClass.class);
+        isInteractionClass(interactionClass);
 
         Predicate<InteractionClassModel> searchPredicate = model -> model.getInteractionClass().equals(interactionClass);
         InteractionClassModel interactionClassModel = federateAmbassador.queryInteractionClassModels(searchPredicate);
@@ -261,7 +309,7 @@ public abstract class SKBaseFederate implements SKFederateInterface {
 
     @Override
     public final void unsubscribeInteractionClass(Class<?> interactionClass) throws FederateNotExecutionMember, RestoreInProgress, InteractionClassNotDefined, NotConnected, RTIinternalError, SaveInProgress {
-        verifyAnnotationExists(interactionClass, InteractionClass.class);
+        isInteractionClass(interactionClass);
 
         Predicate<InteractionClassModel> searchPredicate = model -> model.getInteractionClass().equals(interactionClass);
         InteractionClassModel interactionClassModel = federateAmbassador.queryInteractionClassModels(searchPredicate);
@@ -298,8 +346,8 @@ public abstract class SKBaseFederate implements SKFederateInterface {
             return null;
         }
 
-        verifyAnnotationExists(objectInstanceElement.getClass(), ObjectClass.class);
-        return federateAmbassador.createEntity(objectInstanceElement);
+        String objectClassName = isObjectClass(objectInstanceElement.getClass());
+        return federateAmbassador.createEntity(objectClassName, objectInstanceElement);
     }
 
     @Override
@@ -314,8 +362,8 @@ public abstract class SKBaseFederate implements SKFederateInterface {
             return null;
         }
 
-        verifyAnnotationExists(objectInstanceElement.getClass(), ObjectClass.class);
-        return federateAmbassador.createEntity(objectInstanceElement, requestedName);
+        String objectClassName = isObjectClass(objectInstanceElement.getClass());
+        return federateAmbassador.createEntity(objectClassName, objectInstanceElement, requestedName);
     }
 
     @Override
@@ -324,7 +372,7 @@ public abstract class SKBaseFederate implements SKFederateInterface {
             throw new UpdateException("Failed to send updated object instance values to the RTI because the provided object instance is NULL.");
         }
 
-        verifyAnnotationExists(objectInstance.getClass(), ObjectClass.class);
+        isObjectClass(objectInstance.getClass());
         federateAmbassador.updateEntity(objectInstance);
     }
 
@@ -335,7 +383,7 @@ public abstract class SKBaseFederate implements SKFederateInterface {
             return;
         }
 
-        verifyAnnotationExists(objectInstance.getClass(), ObjectClass.class);
+        isObjectClass(objectInstance.getClass());
         federateAmbassador.deleteEntity(objectInstance, relinquishNameReservation);
     }
 
@@ -346,8 +394,8 @@ public abstract class SKBaseFederate implements SKFederateInterface {
             return false;
         }
 
-        verifyAnnotationExists(interaction.getClass(), InteractionClass.class);
-        return federateAmbassador.sendInteraction(interaction);
+        String interactionClassName = isInteractionClass(interaction.getClass());
+        return federateAmbassador.sendInteraction(interactionClassName, interaction);
     }
 
     @Override

--- a/src/main/java/org/see/skf/core/SKBaseFederate.java
+++ b/src/main/java/org/see/skf/core/SKBaseFederate.java
@@ -146,10 +146,16 @@ public abstract class SKBaseFederate implements SKFederateInterface {
         logger.debug("The RTI ambassador has been disconnected from its RTI.");
     }
 
+    /* This method effectively guarantees that an ObjectClass or InteractionClass annotation is present on the superclass
+     * of the supplied class at the bare minimum.
+     */
     private void verifyAnnotationExists(Class<?> targetClass, Class<? extends Annotation> annotationClass) {
         String errorMessage = "Failed to parse the class " + targetClass.getName() + " because it is missing the " + annotationClass.getName() + " annotation.";
         if (!targetClass.isAnnotationPresent(annotationClass)) {
-            throw new IllegalStateException(errorMessage);
+            Class<?> superClass = targetClass.getSuperclass();
+            if (!(superClass != null && superClass != Object.class && superClass.isAnnotationPresent(annotationClass))) {
+                throw new IllegalStateException(errorMessage);
+            }
         }
     }
 

--- a/src/main/java/org/see/skf/core/SKFederateAmbassador.java
+++ b/src/main/java/org/see/skf/core/SKFederateAmbassador.java
@@ -29,8 +29,6 @@ package org.see.skf.core;
 import hla.rti1516_2025.*;
 import hla.rti1516_2025.exceptions.*;
 import hla.rti1516_2025.time.LogicalTime;
-import org.see.skf.annotations.InteractionClass;
-import org.see.skf.annotations.ObjectClass;
 import org.see.skf.exceptions.UpdateException;
 import org.see.skf.runtime.interactions.InteractionClassModel;
 import org.see.skf.runtime.interactions.InteractionClassModelParser;
@@ -90,19 +88,15 @@ public class SKFederateAmbassador extends NullFederateAmbassador {
     }
 
     final ObjectClassModel addObjectClassModel(Class<?> objectClass) throws FederateNotExecutionMember, NameNotFound, NotConnected, RTIinternalError, InvalidObjectClassHandle {
-        if (objectClass.isAnnotationPresent(ObjectClass.class)) {
-            ObjectClassModelParser parser = new ObjectClassModelParser(objectClass);
-            String className = parser.getFomClassName();
-            RTIambassador rtiAmbassador = HLAUtilityFactory.INSTANCE.getRtiAmbassador();
-            ObjectClassHandle classHandle = rtiAmbassador.getObjectClassHandle(className);
+        ObjectClassModelParser parser = new ObjectClassModelParser(objectClass);
+        String className = parser.getFomClassName();
+        RTIambassador rtiAmbassador = HLAUtilityFactory.INSTANCE.getRtiAmbassador();
+        ObjectClassHandle classHandle = rtiAmbassador.getObjectClassHandle(className);
 
-            ObjectClassModel model = new ObjectClassModel(parser, classHandle);
-            objectClassModels.add(model);
+        ObjectClassModel model = new ObjectClassModel(parser, classHandle);
+        objectClassModels.add(model);
 
-            return model;
-        } else {
-            throw new IllegalStateException("Failed to parse the class <" + objectClass.getName() + "> because it is not annotated with @ObjectClass.");
-        }
+        return model;
     }
 
     final InteractionClassModel queryInteractionClassModels(Predicate<InteractionClassModel> predicate) {
@@ -114,19 +108,15 @@ public class SKFederateAmbassador extends NullFederateAmbassador {
     }
 
     final InteractionClassModel addInteractionClassModel(Class<?> interactionClass) throws FederateNotExecutionMember, NameNotFound, NotConnected, RTIinternalError, InvalidInteractionClassHandle {
-        if (interactionClass.isAnnotationPresent(InteractionClass.class)) {
-            InteractionClassModelParser parser = new InteractionClassModelParser(interactionClass);
-            String className = parser.getFomClassName();
-            RTIambassador rtiAmbassador = HLAUtilityFactory.INSTANCE.getRtiAmbassador();
-            InteractionClassHandle classHandle = rtiAmbassador.getInteractionClassHandle(className);
+        InteractionClassModelParser parser = new InteractionClassModelParser(interactionClass);
+        String className = parser.getFomClassName();
+        RTIambassador rtiAmbassador = HLAUtilityFactory.INSTANCE.getRtiAmbassador();
+        InteractionClassHandle classHandle = rtiAmbassador.getInteractionClassHandle(className);
 
-            InteractionClassModel model = new InteractionClassModel(parser, classHandle);
-            interactionClassModels.add(model);
+        InteractionClassModel model = new InteractionClassModel(parser, classHandle);
+        interactionClassModels.add(model);
 
-            return model;
-        } else {
-            throw new IllegalStateException("Failed to parse the class <" + interactionClass.getName() + "> because it is not annotated with @InteractionClass.");
-        }
+        return model;
     }
 
     final ObjectClassEntity queryEntities(Predicate<ObjectClassEntity> predicate) {
@@ -244,8 +234,7 @@ public class SKFederateAmbassador extends NullFederateAmbassador {
         return remoteEntityToMaturity.get(entity);
     }
 
-    final String createEntity(Object objectInstanceElement) throws FederateNotExecutionMember, ObjectClassNotPublished, ObjectClassNotDefined, RestoreInProgress, NotConnected, RTIinternalError, SaveInProgress, ObjectInstanceNotKnown {
-        String fomClassName = objectInstanceElement.getClass().getAnnotation(ObjectClass.class).name();
+    final String createEntity(String fomClassName, Object objectInstanceElement) throws FederateNotExecutionMember, ObjectClassNotPublished, ObjectClassNotDefined, RestoreInProgress, NotConnected, RTIinternalError, SaveInProgress, ObjectInstanceNotKnown {
         Predicate<ObjectClassModel> searchPredicate = c -> c.getName().equals(fomClassName);
         ObjectClassModel model = queryObjectClassModels(searchPredicate);
 
@@ -273,8 +262,7 @@ public class SKFederateAmbassador extends NullFederateAmbassador {
         return nameRegistry.getOrDefault(name, NameReservationStatus.UNRESERVED);
     }
 
-    final String createEntity(Object objectInstanceElement, String name) throws FederateNotExecutionMember, RestoreInProgress, IllegalName, NotConnected, RTIinternalError, SaveInProgress, ObjectClassNotPublished, ObjectClassNotDefined, ObjectInstanceNameInUse, ObjectInstanceNameNotReserved, ObjectInstanceNotKnown {
-        String fomClassName = objectInstanceElement.getClass().getAnnotation(ObjectClass.class).name();
+    final String createEntity(String fomClassName, Object objectInstanceElement, String name) throws FederateNotExecutionMember, RestoreInProgress, IllegalName, NotConnected, RTIinternalError, SaveInProgress, ObjectClassNotPublished, ObjectClassNotDefined, ObjectInstanceNameInUse, ObjectInstanceNameNotReserved, ObjectInstanceNotKnown {
         Predicate<ObjectClassModel> searchPredicate = c -> c.getName().equals(fomClassName);
         ObjectClassModel model = queryObjectClassModels(searchPredicate);
 
@@ -301,7 +289,7 @@ public class SKFederateAmbassador extends NullFederateAmbassador {
                 return name;
             } else {
                 logger.warn("Failed to reserve \"{}\" for use as an object instance name. Relying on the RTI to allocate a name.", name);
-                createEntity(objectInstanceElement);
+                createEntity(fomClassName, objectInstanceElement);
             }
         } else {
             logger.warn("Failed to create object instance <{}> because it likely has not been published yet.", name);
@@ -384,10 +372,8 @@ public class SKFederateAmbassador extends NullFederateAmbassador {
         }
     }
 
-    public final boolean sendInteraction(Object interactionClassElement) throws FederateNotExecutionMember, InteractionParameterNotDefined, RestoreInProgress, InteractionClassNotDefined, InteractionClassNotPublished, NotConnected, RTIinternalError, SaveInProgress {
-        Class<?> interactionClass = interactionClassElement.getClass();
-        String className = interactionClass.getAnnotation(InteractionClass.class).name();
-        Predicate<InteractionClassModel> searchPredicate = c -> c.getName().equals(className);
+    public final boolean sendInteraction(String fomClassName, Object interactionClassElement) throws FederateNotExecutionMember, InteractionParameterNotDefined, RestoreInProgress, InteractionClassNotDefined, InteractionClassNotPublished, NotConnected, RTIinternalError, SaveInProgress {
+        Predicate<InteractionClassModel> searchPredicate = c -> c.getName().equals(fomClassName);
         InteractionClassModel model = queryInteractionClassModels(searchPredicate);
 
         if (model != null) {

--- a/src/main/java/org/see/skf/runtime/AbstractModelParser.java
+++ b/src/main/java/org/see/skf/runtime/AbstractModelParser.java
@@ -112,6 +112,15 @@ public abstract class AbstractModelParser {
         // Fields have 3 KEY features: FOM name (attribute/parameter), and a Coder.
         // Access level can vary because objects have them at the attribute level, whereas interactions have them at
         // the class level. This functionality is implemented by the subclasses respectively.
+        Field previousField = fomElementNameToField.get(fomName);
+        if (previousField != null) {
+            fields.remove(previousField);
+            fieldToFomElementName.remove(previousField);
+            fieldToCoder.remove(previousField);
+            fieldToGetter.remove(previousField);
+            fieldToSetter.remove(previousField);
+        }
+
         this.fields.add(field);
         this.fomElementNameToField.put(fomName, field);
         this.fieldToFomElementName.put(field, fomName);

--- a/src/main/java/org/see/skf/runtime/AbstractModelParser.java
+++ b/src/main/java/org/see/skf/runtime/AbstractModelParser.java
@@ -131,7 +131,7 @@ public abstract class AbstractModelParser {
         // class fields and the SKF runtime mirrors the rules of the language.
         if (fieldInParent != null) {
             String parentFieldName = getFomElementNameForField(fieldInParent);
-            logger.warn("Redefining the field <{}> is redundant. It is already defined in a parent class.", parentFieldName);
+            logger.warn("Redefining the attribute <{}> is redundant. It is already defined for a field in a parent class.", parentFieldName);
         }
 
         this.fields.add(field);
@@ -142,7 +142,7 @@ public abstract class AbstractModelParser {
         this.fieldToCoder.put(field, coder);
     }
 
-    public final List<Class<?>> getClassHierarchy() {
+    private List<Class<?>> getClassHierarchy() {
         List<Class<?>> hierarchy = new ArrayList<>();
         Class<?> modelClass = getFomClass();
 

--- a/src/main/java/org/see/skf/runtime/AbstractModelParser.java
+++ b/src/main/java/org/see/skf/runtime/AbstractModelParser.java
@@ -40,7 +40,9 @@ public abstract class AbstractModelParser {
 
     // Effectively final - is resolved in the subclasses.
     private String fomClassName;
-    private Class<?> fomClass;
+
+    // The Java (native) class that represents the (object/interaction) class in the HLA FOM.
+    private Class<?> nativeRepresentation;
 
     private final Set<Field> fields;
     private final Map<String, Field> fomElementNameToField;
@@ -49,8 +51,8 @@ public abstract class AbstractModelParser {
     private final Map<Field, Method> fieldToGetter;
     private final Map<Field, Method> fieldToSetter;
 
-    protected AbstractModelParser(Class<?> fomClass) {
-        this.fomClass = fomClass;
+    protected AbstractModelParser(Class<?> nativeRepresentation) {
+        this.nativeRepresentation = nativeRepresentation;
         this.fields = new HashSet<>();
         this.fomElementNameToField = new HashMap<>();
         this.fieldToFomElementName = new HashMap<>();
@@ -63,7 +65,7 @@ public abstract class AbstractModelParser {
         if (hierarchyTraversalNeeded) {
             retrieveModelClassHierarchy();
         } else {
-            processFields(fomClass);
+            processFields(nativeRepresentation);
         }
     }
 
@@ -87,7 +89,7 @@ public abstract class AbstractModelParser {
 
         Method getter;
         try {
-            getter = fomClass.getMethod(getterName);
+            getter = nativeRepresentation.getMethod(getterName);
             fieldToGetter.put(field, getter);
         } catch (NoSuchMethodException e) {
             String fieldName = field.getName();
@@ -96,7 +98,7 @@ public abstract class AbstractModelParser {
 
         try {
             Class<?> getterReturnType = getter.getReturnType();
-            Method setter = fomClass.getMethod(setterName, getterReturnType);
+            Method setter = nativeRepresentation.getMethod(setterName, getterReturnType);
             fieldToSetter.put(field, setter);
         } catch (NoSuchMethodException e) {
             String fieldName = field.getName();
@@ -144,7 +146,7 @@ public abstract class AbstractModelParser {
 
     private List<Class<?>> getClassHierarchy() {
         List<Class<?>> hierarchy = new ArrayList<>();
-        Class<?> modelClass = getFomClass();
+        Class<?> modelClass = getNativeRepresentation();
 
         while (modelClass != null && modelClass != Object.class) {
             hierarchy.add(0, modelClass);
@@ -166,12 +168,12 @@ public abstract class AbstractModelParser {
         this.fomClassName = fomClassName;
     }
 
-    public final Class<?> getFomClass() {
-        return fomClass;
+    public final Class<?> getNativeRepresentation() {
+        return nativeRepresentation;
     }
 
-    public final void setFomClass(Class<?> fomClass) {
-        this.fomClass = fomClass;
+    public final void setNativeRepresentation(Class<?> nativeRepresentation) {
+        this.nativeRepresentation = nativeRepresentation;
     }
 
     public final Set<Field> getAllFields() {

--- a/src/main/java/org/see/skf/runtime/AbstractModelParser.java
+++ b/src/main/java/org/see/skf/runtime/AbstractModelParser.java
@@ -32,10 +32,7 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 public abstract class AbstractModelParser {
     protected static final Logger logger = LoggerFactory.getLogger(AbstractModelParser.class);
@@ -43,8 +40,8 @@ public abstract class AbstractModelParser {
 
     // Effectively final - is resolved in the subclasses.
     private String fomClassName;
+    private Class<?> fomClass;
 
-    private final Class<?> fomClass;
     private final Set<Field> fields;
     private final Map<String, Field> fomElementNameToField;
     private final Map<Field, String> fieldToFomElementName;
@@ -61,10 +58,26 @@ public abstract class AbstractModelParser {
         this.fieldToGetter = new HashMap<>();
         this.fieldToSetter = new HashMap<>();
 
-        retrieveModelStructure();
+        boolean hierarchyTraversalNeeded = retrieveModelType();
+
+        if (hierarchyTraversalNeeded) {
+            retrieveModelClassHierarchy();
+        } else {
+            processFields(fomClass);
+        }
     }
 
-    protected abstract void retrieveModelStructure();
+    private void retrieveModelClassHierarchy() {
+        List<Class<?>> classHierarchy = getClassHierarchy();
+
+        if (!classHierarchy.isEmpty()) {
+            classHierarchy.forEach(this::processFields);
+        }
+    }
+
+    protected abstract boolean retrieveModelType();
+
+    protected abstract void processFields(Class<?> clazz);
 
     public abstract Map<String, byte[]> encode(Object element);
 
@@ -91,7 +104,7 @@ public abstract class AbstractModelParser {
         }
     }
 
-    public String generateMethodName(String prefix, String fieldName) {
+    public final String generateMethodName(String prefix, String fieldName) {
         String[] fieldNameSplit = fieldName.split(REGEX);
 
         for (int i = 0; i < fieldNameSplit.length; i++) {
@@ -108,17 +121,17 @@ public abstract class AbstractModelParser {
         return result.toString();
     }
 
-    public void addField(String fomName, Field field, Class<? extends Coder<?>> coder) {
+    public final void addField(String fomName, Field field, Class<? extends Coder<?>> coder) {
         // Fields have 3 KEY features: FOM name (attribute/parameter), and a Coder.
-        // Access level can vary because objects have them at the attribute level, whereas interactions have them at
+        // Scope level can vary because objects have them at the attribute level, whereas interactions have them at
         // the class level. This functionality is implemented by the subclasses respectively.
-        Field previousField = fomElementNameToField.get(fomName);
-        if (previousField != null) {
-            fields.remove(previousField);
-            fieldToFomElementName.remove(previousField);
-            fieldToCoder.remove(previousField);
-            fieldToGetter.remove(previousField);
-            fieldToSetter.remove(previousField);
+        Field fieldInParent = fomElementNameToField.get(fomName);
+
+        // Disallow for attributes to be re-evaluated by subclasses. Java does not permit the overloading of
+        // class fields and the SKF runtime mirrors the rules of the language.
+        if (fieldInParent != null) {
+            String parentFieldName = getFomElementNameForField(fieldInParent);
+            logger.warn("Redefining the field <{}> is redundant. It is already defined in a parent class.", parentFieldName);
         }
 
         this.fields.add(field);
@@ -129,39 +142,55 @@ public abstract class AbstractModelParser {
         this.fieldToCoder.put(field, coder);
     }
 
+    public final List<Class<?>> getClassHierarchy() {
+        List<Class<?>> hierarchy = new ArrayList<>();
+        Class<?> modelClass = getFomClass();
+
+        while (modelClass != null && modelClass != Object.class) {
+            hierarchy.add(0, modelClass);
+            modelClass = modelClass.getSuperclass();
+        }
+
+        return hierarchy;
+    }
+
     private String capitalize(String word) {
         return word.substring(0, 1).toUpperCase() + word.substring(1);
     }
 
-    public String getFomClassName() {
+    public final String getFomClassName() {
         return fomClassName;
     }
 
-    public void setFomClassName(String fomClassName) {
+    public final void setFomClassName(String fomClassName) {
         this.fomClassName = fomClassName;
     }
 
-    public Class<?> getFomClass() {
+    public final Class<?> getFomClass() {
         return fomClass;
     }
 
-    public Set<Field> getAllFields() {
+    public final void setFomClass(Class<?> fomClass) {
+        this.fomClass = fomClass;
+    }
+
+    public final Set<Field> getAllFields() {
         return fields;
     }
 
-    public Field getFieldForFomElement(String fomName) {
+    public final Field getFieldForFomElement(String fomName) {
         return fomElementNameToField.get(fomName);
     }
 
-    public String getFomElementNameForField(Field field) {
+    public final String getFomElementNameForField(Field field) {
         return fieldToFomElementName.get(field);
     }
 
-    public Method getFieldGetter(Field field) {
+    public final Method getFieldGetter(Field field) {
         return fieldToGetter.get(field);
     }
 
-    public Method getFieldSetter(Field field) {
+    public final Method getFieldSetter(Field field) {
         return fieldToSetter.get(field);
     }
 

--- a/src/main/java/org/see/skf/runtime/interactions/InteractionClassModel.java
+++ b/src/main/java/org/see/skf/runtime/interactions/InteractionClassModel.java
@@ -144,7 +144,7 @@ public final class InteractionClassModel extends AbstractClassModel {
     }
 
     public Class<?> getInteractionClass() {
-        return parser.getFomClass();
+        return parser.getNativeRepresentation();
     }
 
     @Override

--- a/src/main/java/org/see/skf/runtime/interactions/InteractionClassModelParser.java
+++ b/src/main/java/org/see/skf/runtime/interactions/InteractionClassModelParser.java
@@ -50,24 +50,39 @@ public final class InteractionClassModelParser extends AbstractModelParser {
     }
 
     @Override
-    protected void retrieveModelStructure() {
+    protected boolean retrieveModelType() {
+        boolean traversalNeeded = false;
         InteractionClass interactionClass = getFomClass().getAnnotation(InteractionClass.class);
-        setFomClassName(interactionClass.name());
 
-        parameterNames = new HashSet<>();
-        Field[] classFields = getFomClass().getDeclaredFields();
+        if (interactionClass == null) {
+            Class<?> superClass = getFomClass().getSuperclass();
+            interactionClass = superClass.getAnnotation(InteractionClass.class);
+            setFomClass(superClass);
+            traversalNeeded = true;
+        }
+
+        setFomClassName(interactionClass.name());
+        this.parameterNames = new HashSet<>();
+
+
+        logger.debug("Generated model class structure for the HLA interaction class <{}>.", interactionClass.name());
+        return traversalNeeded;
+    }
+
+    @Override
+    protected void processFields(Class<?> clazz) {
+        Field[] classFields = clazz.getDeclaredFields();
         for (Field field : classFields) {
             if (field.isAnnotationPresent(Parameter.class)) {
                 Parameter parameter = field.getAnnotation(Parameter.class);
                 String parameterName = parameter.name();
+
                 Class<? extends Coder<?>> coderClass = parameter.coder();
 
                 addField(parameterName, field, coderClass);
                 parameterNames.add(parameterName);
             }
         }
-
-        logger.debug("Generated model class structure for the HLA interaction class <{}>.", interactionClass.name());
     }
 
     @Override
@@ -99,31 +114,31 @@ public final class InteractionClassModelParser extends AbstractModelParser {
     }
 
     public void decode(Object element, ParameterHandleValueMap parameterHandleToValue, Map<ParameterHandle, String> parameterHandleToName) {
-            try {
-                for (var entry : parameterHandleToValue.entrySet()) {
-                    String parameterName = parameterHandleToName.get(entry.getKey());
+        try {
+            for (var entry : parameterHandleToValue.entrySet()) {
+                String parameterName = parameterHandleToName.get(entry.getKey());
 
-                    Field field = getFieldForFomElement(parameterName);
-                    var coderClass = getFieldCoder(field);
-                    Coder<?> coder = CoderCollection.query(coderClass);
+                Field field = getFieldForFomElement(parameterName);
+                var coderClass = getFieldCoder(field);
+                Coder<?> coder = CoderCollection.query(coderClass);
 
-                    var decode = coderClass.getMethod("decode", byte[].class);
-                    var encodedValue = entry.getValue();
+                var decode = coderClass.getMethod("decode", byte[].class);
+                var encodedValue = entry.getValue();
 
-                    // IntelliJ will warn you here that the following line is incorrect. Changing the second argument to
-                    // Object.class makes the warning go away. Be wise, and do not heed its words. All is as it should be.
-                    // Using byte[].class for the parameter type is, in fact, the correct choice - decoding won't work
-                    // otherwise.
-                    Object newFieldValue = decode.invoke(coder, encodedValue);
-                    Method setter = getFieldSetter(field);
+                // IntelliJ will warn you here that the following line is incorrect. Changing the second argument to
+                // Object.class makes the warning go away. Be wise, and do not heed its words. All is as it should be.
+                // Using byte[].class for the parameter type is, in fact, the correct choice - decoding won't work
+                // otherwise.
+                Object newFieldValue = decode.invoke(coder, encodedValue);
+                Method setter = getFieldSetter(field);
 
-                    setter.invoke(element, newFieldValue);
-                }
-            } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-                throw new IllegalStateException("Unexpected problem encountered when trying to decode the latest values for an HLA interaction <" + element + "> of the type <" + getFomClassName() + ">" + e);
-            } catch (IllegalArgumentException e) {
-                throw new IllegalArgumentException("Mismatch in fields of interaction class detected. Ensure object fields are properly initialized and the getter and setter methods are of the correct type.");
+                setter.invoke(element, newFieldValue);
             }
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            throw new IllegalStateException("Unexpected problem encountered when trying to decode the latest values for an HLA interaction <" + element + "> of the type <" + getFomClassName() + ">" + e);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Mismatch in fields of interaction class detected. Ensure object fields are properly initialized and the getter and setter methods are of the correct type.");
+        }
     }
 
     public Set<String> getParameterNames() {

--- a/src/main/java/org/see/skf/runtime/interactions/InteractionClassModelParser.java
+++ b/src/main/java/org/see/skf/runtime/interactions/InteractionClassModelParser.java
@@ -51,15 +51,18 @@ public final class InteractionClassModelParser extends AbstractModelParser {
 
     @Override
     protected boolean retrieveModelType() {
-        InteractionClass interactionClass = getFomClass().getAnnotation(InteractionClass.class);
+        InteractionClass interactionClass = getNativeRepresentation().getAnnotation(InteractionClass.class);
 
-        Class<?> superClass = getFomClass().getSuperclass();
-        InteractionClass superInteractionClassAnnotation = superClass.getAnnotation(InteractionClass.class);
-
-        boolean traversalNeeded = superInteractionClassAnnotation != null;
+        boolean traversalNeeded = false;
         if (interactionClass == null) {
-            interactionClass = superClass.getAnnotation(InteractionClass.class);
-            setFomClass(superClass);
+            Class<?> ancestor = locateAncestorWithAnnotation(getNativeRepresentation());
+            interactionClass = ancestor.getAnnotation(InteractionClass.class);
+            traversalNeeded = true;
+        }
+
+        Class<?> superClass = getNativeRepresentation().getSuperclass();
+        if (superClass != null && superClass.isAnnotationPresent(InteractionClass.class)) {
+            traversalNeeded = true;
         }
 
         setFomClassName(interactionClass.name());
@@ -83,6 +86,19 @@ public final class InteractionClassModelParser extends AbstractModelParser {
                 parameterNames.add(parameterName);
             }
         }
+    }
+
+    private Class<?> locateAncestorWithAnnotation(Class<?> clazz) {
+        while (clazz != Object.class) {
+            clazz = clazz.getSuperclass();
+            InteractionClass annotation = clazz.getAnnotation(InteractionClass.class);
+
+            if (annotation != null) {
+                break;
+            }
+        }
+
+        return clazz;
     }
 
     @Override

--- a/src/main/java/org/see/skf/runtime/interactions/InteractionClassModelParser.java
+++ b/src/main/java/org/see/skf/runtime/interactions/InteractionClassModelParser.java
@@ -51,19 +51,19 @@ public final class InteractionClassModelParser extends AbstractModelParser {
 
     @Override
     protected boolean retrieveModelType() {
-        boolean traversalNeeded = false;
         InteractionClass interactionClass = getFomClass().getAnnotation(InteractionClass.class);
 
+        Class<?> superClass = getFomClass().getSuperclass();
+        InteractionClass superInteractionClassAnnotation = superClass.getAnnotation(InteractionClass.class);
+
+        boolean traversalNeeded = superInteractionClassAnnotation != null;
         if (interactionClass == null) {
-            Class<?> superClass = getFomClass().getSuperclass();
             interactionClass = superClass.getAnnotation(InteractionClass.class);
             setFomClass(superClass);
-            traversalNeeded = true;
         }
 
         setFomClassName(interactionClass.name());
         this.parameterNames = new HashSet<>();
-
 
         logger.debug("Generated model class structure for the HLA interaction class <{}>.", interactionClass.name());
         return traversalNeeded;

--- a/src/main/java/org/see/skf/runtime/objects/ObjectClassModel.java
+++ b/src/main/java/org/see/skf/runtime/objects/ObjectClassModel.java
@@ -162,7 +162,7 @@ public final class ObjectClassModel extends AbstractClassModel {
     }
 
     public Class<?> getObjectClass() {
-        return parser.getFomClass();
+        return parser.getNativeRepresentation();
     }
 
     public AttributeHandleSet getPublicationSet() {

--- a/src/main/java/org/see/skf/runtime/objects/ObjectClassModelParser.java
+++ b/src/main/java/org/see/skf/runtime/objects/ObjectClassModelParser.java
@@ -39,12 +39,7 @@ import org.see.skf.runtime.ScopeLevel;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 public final class ObjectClassModelParser extends AbstractModelParser {
     private Set<String> publishableAttributeNames;
@@ -55,40 +50,41 @@ public final class ObjectClassModelParser extends AbstractModelParser {
     }
 
     @Override
-    protected void retrieveModelStructure() {
+    protected boolean retrieveModelType() {
         ObjectClass objectClass = getFomClass().getAnnotation(ObjectClass.class);
+
+        Class<?> superClass = getFomClass().getSuperclass();
+        ObjectClass superObjectClassAnnotation = superClass.getAnnotation(ObjectClass.class);
+
+        boolean traversalNeeded = superObjectClassAnnotation != null;
+        if (objectClass == null) {
+            objectClass = superClass.getAnnotation(ObjectClass.class);
+            setFomClass(superClass);
+        }
+
         setFomClassName(objectClass.name());
         this.publishableAttributeNames = new HashSet<>();
         this.subscribableAttributeNames = new HashSet<>();
 
-        for (Class<?> modelClass : getModelHierarchy()) {
-            Field[] classFields = modelClass.getDeclaredFields();
-            for (Field field : classFields) {
-                if (field.isAnnotationPresent(Attribute.class)) {
-                    Attribute attribute = field.getAnnotation(Attribute.class);
-                    String attributeName = attribute.name();
-                    Class<? extends Coder<?>> coderClass = attribute.coder();
-                    ScopeLevel scopeLevel = attribute.scope();
-
-                    addField(attributeName, field, coderClass);
-                    setAttributeAccessLevel(attributeName, scopeLevel);
-                }
-            }
-        }
-
         logger.debug("Generated model class structure for the HLA object class <{}>.", objectClass.name());
+        return traversalNeeded;
     }
 
-    private List<Class<?>> getModelHierarchy() {
-        List<Class<?>> hierarchy = new ArrayList<>();
-        Class<?> modelClass = getFomClass();
+    @Override
+    protected void processFields(Class<?> clazz) {
+        Field[] classFields = clazz.getDeclaredFields();
+        for (Field field : classFields) {
+            if (field.isAnnotationPresent(Attribute.class)) {
+                Attribute attribute = field.getAnnotation(Attribute.class);
+                String attributeName = attribute.name();
 
-        while (modelClass != null && modelClass != Object.class) {
-            hierarchy.add(0, modelClass);
-            modelClass = modelClass.getSuperclass();
+                Class<? extends Coder<?>> coderClass = attribute.coder();
+                ScopeLevel scopeLevel = attribute.scope();
+
+                addField(attributeName, field, coderClass);
+                setAttributeAccessLevel(attributeName, scopeLevel);
+            }
         }
-
-        return hierarchy;
     }
 
     @Override
@@ -158,9 +154,6 @@ public final class ObjectClassModelParser extends AbstractModelParser {
     }
 
     private void setAttributeAccessLevel(String attributeName, ScopeLevel scopeLevel) {
-        publishableAttributeNames.remove(attributeName);
-        subscribableAttributeNames.remove(attributeName);
-
         if (scopeLevel == ScopeLevel.PUBLISH_SUBSCRIBE) {
             publishableAttributeNames.add(attributeName);
             subscribableAttributeNames.add(attributeName);

--- a/src/main/java/org/see/skf/runtime/objects/ObjectClassModelParser.java
+++ b/src/main/java/org/see/skf/runtime/objects/ObjectClassModelParser.java
@@ -39,8 +39,10 @@ import org.see.skf.runtime.ScopeLevel;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -59,20 +61,34 @@ public final class ObjectClassModelParser extends AbstractModelParser {
         this.publishableAttributeNames = new HashSet<>();
         this.subscribableAttributeNames = new HashSet<>();
 
-        Field[] classFields = getFomClass().getDeclaredFields();
-        for (Field field : classFields) {
-            if (field.isAnnotationPresent(Attribute.class)) {
-                Attribute attribute = field.getAnnotation(Attribute.class);
-                String attributeName = attribute.name();
-                Class<? extends Coder<?>> coderClass = attribute.coder();
-                ScopeLevel scopeLevel = attribute.scope();
+        for (Class<?> modelClass : getModelHierarchy()) {
+            Field[] classFields = modelClass.getDeclaredFields();
+            for (Field field : classFields) {
+                if (field.isAnnotationPresent(Attribute.class)) {
+                    Attribute attribute = field.getAnnotation(Attribute.class);
+                    String attributeName = attribute.name();
+                    Class<? extends Coder<?>> coderClass = attribute.coder();
+                    ScopeLevel scopeLevel = attribute.scope();
 
-                addField(attributeName, field, coderClass);
-                setAttributeAccessLevel(attributeName, scopeLevel);
+                    addField(attributeName, field, coderClass);
+                    setAttributeAccessLevel(attributeName, scopeLevel);
+                }
             }
         }
 
         logger.debug("Generated model class structure for the HLA object class <{}>.", objectClass.name());
+    }
+
+    private List<Class<?>> getModelHierarchy() {
+        List<Class<?>> hierarchy = new ArrayList<>();
+        Class<?> modelClass = getFomClass();
+
+        while (modelClass != null && modelClass != Object.class) {
+            hierarchy.add(0, modelClass);
+            modelClass = modelClass.getSuperclass();
+        }
+
+        return hierarchy;
     }
 
     @Override
@@ -142,6 +158,9 @@ public final class ObjectClassModelParser extends AbstractModelParser {
     }
 
     private void setAttributeAccessLevel(String attributeName, ScopeLevel scopeLevel) {
+        publishableAttributeNames.remove(attributeName);
+        subscribableAttributeNames.remove(attributeName);
+
         if (scopeLevel == ScopeLevel.PUBLISH_SUBSCRIBE) {
             publishableAttributeNames.add(attributeName);
             subscribableAttributeNames.add(attributeName);

--- a/src/main/java/org/see/skf/runtime/objects/ObjectClassModelParser.java
+++ b/src/main/java/org/see/skf/runtime/objects/ObjectClassModelParser.java
@@ -51,15 +51,18 @@ public final class ObjectClassModelParser extends AbstractModelParser {
 
     @Override
     protected boolean retrieveModelType() {
-        ObjectClass objectClass = getFomClass().getAnnotation(ObjectClass.class);
+        ObjectClass objectClass = getNativeRepresentation().getAnnotation(ObjectClass.class);
 
-        Class<?> superClass = getFomClass().getSuperclass();
-        ObjectClass superObjectClassAnnotation = superClass.getAnnotation(ObjectClass.class);
-
-        boolean traversalNeeded = superObjectClassAnnotation != null;
+        boolean traversalNeeded = false;
         if (objectClass == null) {
-            objectClass = superClass.getAnnotation(ObjectClass.class);
-            setFomClass(superClass);
+            Class<?> ancestor = locateAncestorWithAnnotation(getNativeRepresentation());
+            objectClass = ancestor.getAnnotation(ObjectClass.class);
+            traversalNeeded = true;
+        }
+
+        Class<?> superClass = getNativeRepresentation().getSuperclass();
+        if (superClass != null && superClass.isAnnotationPresent(ObjectClass.class)) {
+            traversalNeeded = true;
         }
 
         setFomClassName(objectClass.name());
@@ -85,6 +88,19 @@ public final class ObjectClassModelParser extends AbstractModelParser {
                 setAttributeAccessLevel(attributeName, scopeLevel);
             }
         }
+    }
+
+    private Class<?> locateAncestorWithAnnotation(Class<?> clazz) {
+        while (clazz != Object.class) {
+            clazz = clazz.getSuperclass();
+            ObjectClass annotation = clazz.getAnnotation(ObjectClass.class);
+
+            if (annotation != null) {
+                break;
+            }
+        }
+
+        return clazz;
     }
 
     @Override

--- a/src/test/java/org/see/skf/runtime/InteractionClassModelParserTest.java
+++ b/src/test/java/org/see/skf/runtime/InteractionClassModelParserTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.see.skf.annotations.InteractionClass;
 import org.see.skf.annotations.Parameter;
 import org.see.skf.util.encoding.HLAfloat64LECoder;
+import org.see.skf.util.encoding.HLAinteger16BECoder;
 import org.see.skf.util.encoding.HLAunicodeStringCoder;
 import org.see.skf.util.models.ModeTransitionRequest;
 import org.see.skf.runtime.interactions.InteractionClassModelParser;
@@ -18,6 +19,7 @@ class InteractionClassModelParserTest {
     final InteractionClassModelParser baseInteractionParser = new InteractionClassModelParser(BaseInteraction.class);
     final InteractionClassModelParser dockingRequestInteractionParser = new InteractionClassModelParser(DockingRequestInteraction.class);
     final InteractionClassModelParser repairRequestInteractionParser = new InteractionClassModelParser(RepairRequestInteraction.class);
+    final InteractionClassModelParser repairRequestCompleteInteractionParser = new InteractionClassModelParser(RepairRequestCompleteInteraction.class);
 
     @Test
     void testMetadata() {
@@ -75,6 +77,24 @@ class InteractionClassModelParserTest {
         Set<String> parameterNames = repairRequestInteractionParser.getParameterNames();
         assertTrue(parameterNames.contains("sender"));
         assertTrue(parameterNames.contains("target_object"));
+    }
+
+    @Test
+    void testRepairRequestCompleteFields() {
+        Field senderField = repairRequestCompleteInteractionParser.getFieldForFomElement("sender");
+        Field targetObjectField = repairRequestCompleteInteractionParser.getFieldForFomElement("target_object");
+        Field messageIdField = repairRequestCompleteInteractionParser.getFieldForFomElement("messageId");
+        Field repairCodeField = repairRequestCompleteInteractionParser.getFieldForFomElement("repair_code");
+
+        assertNotNull(senderField);
+        assertNotNull(targetObjectField);
+        assertNull(messageIdField);
+        assertNotNull(repairCodeField);
+
+        Set<String> parameterNames = repairRequestCompleteInteractionParser.getParameterNames();
+        assertTrue(parameterNames.contains("sender"));
+        assertTrue(parameterNames.contains("target_object"));
+        assertTrue(parameterNames.contains("repair_code"));
     }
 
     @InteractionClass(name = "HLAinteractionRoot.BaseInteraction")
@@ -138,6 +158,21 @@ class InteractionClassModelParserTest {
 
         public void setMessageId(String messageId) {
             this.messageId = messageId;
+        }
+    }
+
+    static class RepairRequestCompleteInteraction extends RepairRequestInteraction {
+        @Parameter(name = "repair_code", coder = HLAinteger16BECoder.class)
+        private short repairCode;
+
+        public RepairRequestCompleteInteraction() { super(); }
+
+        public short getRepairCode() {
+            return repairCode;
+        }
+
+        public void setRepairCode(short repairCode) {
+            this.repairCode = repairCode;
         }
     }
 }

--- a/src/test/java/org/see/skf/runtime/InteractionClassModelParserTest.java
+++ b/src/test/java/org/see/skf/runtime/InteractionClassModelParserTest.java
@@ -1,16 +1,23 @@
 package org.see.skf.runtime;
 
 import org.junit.jupiter.api.Test;
+import org.see.skf.annotations.InteractionClass;
+import org.see.skf.annotations.Parameter;
+import org.see.skf.util.encoding.HLAfloat64LECoder;
+import org.see.skf.util.encoding.HLAunicodeStringCoder;
 import org.see.skf.util.models.ModeTransitionRequest;
 import org.see.skf.runtime.interactions.InteractionClassModelParser;
 
 import java.lang.reflect.Field;
+import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 class InteractionClassModelParserTest {
     final InteractionClassModelParser parser = new InteractionClassModelParser(ModeTransitionRequest.class);
+    final InteractionClassModelParser baseInteractionParser = new InteractionClassModelParser(BaseInteraction.class);
+    final InteractionClassModelParser dockingRequestInteractionParser = new InteractionClassModelParser(DockingRequestInteraction.class);
+    final InteractionClassModelParser repairRequestInteractionParser = new InteractionClassModelParser(RepairRequestInteraction.class);
 
     @Test
     void testMetadata() {
@@ -22,5 +29,115 @@ class InteractionClassModelParserTest {
         assertNotNull(parser.getFieldSetter(name));
         assertNotNull(parser.getFieldCoder(name));
         assertNotNull(CoderCollection.query(parser.getFieldCoder(name)));
+    }
+
+    @Test
+    void testBaseInteractionFields() {
+        assertEquals("HLAinteractionRoot.BaseInteraction", baseInteractionParser.getFomClassName());
+
+        Field senderField = baseInteractionParser.getFieldForFomElement("sender");
+        Field targetObjectField = baseInteractionParser.getFieldForFomElement("target_object");
+
+        assertNotNull(senderField);
+        assertNotNull(targetObjectField);
+
+        Set<String> parameterNames = baseInteractionParser.getParameterNames();
+        assertTrue(parameterNames.contains("sender"));
+        assertTrue(parameterNames.contains("target_object"));
+    }
+
+    @Test
+    void testDockingRequestFields() {
+        Field senderField = dockingRequestInteractionParser.getFieldForFomElement("sender");
+        Field targetObjectField = dockingRequestInteractionParser.getFieldForFomElement("target_object");
+        Field zDistanceField = dockingRequestInteractionParser.getFieldForFomElement("z_distance");
+
+        assertNotNull(senderField);
+        assertNotNull(targetObjectField);
+        assertNotNull(zDistanceField);
+
+        Set<String> parameterNames = dockingRequestInteractionParser.getParameterNames();
+        assertTrue(parameterNames.contains("sender"));
+        assertTrue(parameterNames.contains("target_object"));
+        assertTrue(parameterNames.contains("z_distance"));
+    }
+
+    @Test
+    void testRepairRequestFields() {
+        Field senderField = repairRequestInteractionParser.getFieldForFomElement("sender");
+        Field targetObjectField = repairRequestInteractionParser.getFieldForFomElement("target_object");
+        Field messageIdField = repairRequestInteractionParser.getFieldForFomElement("messageId");
+
+        assertNotNull(senderField);
+        assertNotNull(targetObjectField);
+        assertNull(messageIdField);
+
+        Set<String> parameterNames = repairRequestInteractionParser.getParameterNames();
+        assertTrue(parameterNames.contains("sender"));
+        assertTrue(parameterNames.contains("target_object"));
+    }
+
+    @InteractionClass(name = "HLAinteractionRoot.BaseInteraction")
+    static class BaseInteraction {
+        @Parameter(name = "sender", coder = HLAunicodeStringCoder.class)
+        private String sender;
+
+        @Parameter(name = "target_object", coder = HLAunicodeStringCoder.class)
+        private String targetObject;
+
+        public BaseInteraction() {
+            this.sender = "orion_spacecraft";
+            this.targetObject = "gateway";
+        }
+
+        public String getSender() {
+            return sender;
+        }
+
+        public void setSender(String sender) {
+            this.sender = sender;
+        }
+
+        public String getTargetObject() {
+            return targetObject;
+        }
+
+        public void setTargetObject(String targetObject) {
+            this.targetObject = targetObject;
+        }
+    }
+
+    @InteractionClass(name = "HLAinteractionRoot.BaseInteraction.DockingRequestInteraction")
+    static class DockingRequestInteraction extends BaseInteraction {
+        @Parameter(name = "z_distance", coder = HLAfloat64LECoder.class)
+        private double zDistance;
+
+        public DockingRequestInteraction() {
+            this.zDistance = 12.0;
+        }
+
+        public Double getZDistance() {
+            return zDistance;
+        }
+
+        public void setZDistance(Double zDistance) {
+            this.zDistance = zDistance;
+        }
+    }
+
+    static class RepairRequestInteraction extends BaseInteraction {
+        private String messageId;
+
+        public RepairRequestInteraction() {
+            super();
+        }
+
+        public String getMessageId() {
+            return messageId;
+        }
+
+        public void setMessageId(String messageId) {
+            this.messageId = messageId;
+        }
     }
 }

--- a/src/test/java/org/see/skf/runtime/ObjectClassModelParserTest.java
+++ b/src/test/java/org/see/skf/runtime/ObjectClassModelParserTest.java
@@ -1,13 +1,20 @@
 package org.see.skf.runtime;
 
 import org.junit.jupiter.api.Test;
+import org.see.skf.annotations.Attribute;
+import org.see.skf.annotations.ObjectClass;
 import org.see.skf.util.models.ExecutionConfiguration;
+import org.see.skf.util.encoding.HLAfloat64LECoder;
+import org.see.skf.util.encoding.HLAunicodeStringCoder;
 import org.see.skf.runtime.objects.ObjectClassModelParser;
 
 import java.lang.reflect.Field;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ObjectClassModelParserTest {
     final ObjectClassModelParser parser = new ObjectClassModelParser(ExecutionConfiguration.class);
@@ -49,5 +56,109 @@ class ObjectClassModelParserTest {
         assertEquals("setPositionVector", parser.generateMethodName("set", "positionVector"));
         assertEquals("getPhysicalInterface", parser.generateMethodName("get", "physicalInterface"));
         assertEquals("setPhysicalInterface", parser.generateMethodName("set", "physicalInterface"));
+    }
+
+    @Test
+    void testSubclassInheritsParentAttributes() {
+        ObjectClassModelParser subclassParser = new ObjectClassModelParser(TestChildObject.class);
+
+        Set<String> publishableAttributes = subclassParser.getPublishableAttributeNames();
+        assertTrue(publishableAttributes.contains("parent_name"));
+        assertTrue(publishableAttributes.contains("shared_status"));
+        assertTrue(publishableAttributes.contains("child_mass"));
+        assertFalse(publishableAttributes.contains("parent_subscribe_only"));
+
+        Set<String> subscribableAttributes = subclassParser.getSubscribableAttributeNames();
+        assertTrue(subscribableAttributes.contains("parent_name"));
+        assertTrue(subscribableAttributes.contains("shared_status"));
+        assertTrue(subscribableAttributes.contains("child_mass"));
+        assertTrue(subscribableAttributes.contains("parent_subscribe_only"));
+
+        Field parentName = subclassParser.getFieldForFomElement("parent_name");
+        Field parentState = subclassParser.getFieldForFomElement("shared_status");
+        Field childMass = subclassParser.getFieldForFomElement("child_mass");
+        Field parentSubscribeOnly = subclassParser.getFieldForFomElement("parent_subscribe_only");
+
+        assertNotNull(parentName);
+        assertNotNull(parentState);
+        assertNotNull(childMass);
+        assertNotNull(parentSubscribeOnly);
+
+        assertEquals(TestParentObject.class, parentName.getDeclaringClass());
+        assertEquals(TestChildObject.class, parentState.getDeclaringClass());
+        assertEquals(TestChildObject.class, childMass.getDeclaringClass());
+
+        assertNotNull(subclassParser.getFieldGetter(parentName));
+        assertNotNull(subclassParser.getFieldSetter(parentName));
+        assertNotNull(subclassParser.getFieldGetter(parentState));
+        assertNotNull(subclassParser.getFieldSetter(parentState));
+
+        assertEquals(ScopeLevel.PUBLISH_SUBSCRIBE, subclassParser.getAttributeAccessLevel("parent_name"));
+        assertEquals(ScopeLevel.PUBLISH_SUBSCRIBE, subclassParser.getAttributeAccessLevel("shared_status"));
+        assertEquals(ScopeLevel.PUBLISH_SUBSCRIBE, subclassParser.getAttributeAccessLevel("child_mass"));
+        assertEquals(ScopeLevel.SUBSCRIBE, subclassParser.getAttributeAccessLevel("parent_subscribe_only"));
+    }
+
+    @ObjectClass(name = "HLAobjectRoot.TestParentObject")
+    public static class TestParentObject {
+        @Attribute(name = "parent_name", coder = HLAunicodeStringCoder.class)
+        private String parentName = "";
+
+        @Attribute(name = "shared_status", coder = HLAunicodeStringCoder.class)
+        private String sharedStatus = "";
+
+        @Attribute(name = "parent_subscribe_only", coder = HLAunicodeStringCoder.class, scope = ScopeLevel.SUBSCRIBE)
+        private String parentSubscribeOnly = "";
+
+        public String getParentName() {
+            return parentName;
+        }
+
+        public void setParentName(String parentName) {
+            this.parentName = parentName;
+        }
+
+        public String getSharedStatus() {
+            return sharedStatus;
+        }
+
+        public void setSharedStatus(String sharedStatus) {
+            this.sharedStatus = sharedStatus;
+        }
+
+        public String getParentSubscribeOnly() {
+            return parentSubscribeOnly;
+        }
+
+        public void setParentSubscribeOnly(String parentSubscribeOnly) {
+            this.parentSubscribeOnly = parentSubscribeOnly;
+        }
+    }
+
+    @ObjectClass(name = "HLAobjectRoot.TestParentObject.TestChildObject")
+    public static class TestChildObject extends TestParentObject {
+        @Attribute(name = "shared_status", coder = HLAunicodeStringCoder.class)
+        private String sharedStatus = "";
+
+        @Attribute(name = "child_mass", coder = HLAfloat64LECoder.class)
+        private Double childMass = 0.0;
+
+        @Override
+        public String getSharedStatus() {
+            return sharedStatus;
+        }
+
+        @Override
+        public void setSharedStatus(String sharedStatus) {
+            this.sharedStatus = sharedStatus;
+        }
+
+        public Double getChildMass() {
+            return childMass;
+        }
+
+        public void setChildMass(Double childMass) {
+            this.childMass = childMass;
+        }
     }
 }

--- a/src/test/java/org/see/skf/runtime/ObjectClassModelParserTest.java
+++ b/src/test/java/org/see/skf/runtime/ObjectClassModelParserTest.java
@@ -23,7 +23,7 @@ class ObjectClassModelParserTest {
     final ObjectClassModelParser roverParser = new ObjectClassModelParser(Rover.class);
 
     @Test
-    void testMetadata() {
+    void testBasicMetadata() {
         assertEquals("HLAobjectRoot.ExecutionConfiguration", exCOParser.getFomClassName());
         assertNotNull(exCOParser.getFieldForFomElement("root_frame_name"));
         assertNotNull(exCOParser.getFieldForFomElement("least_common_time_step"));
@@ -52,7 +52,7 @@ class ObjectClassModelParserTest {
     }
 
     @Test
-    void testMethodGeneration() {
+    void testBasicMethodGeneration() {
         assertEquals("getValue", exCOParser.generateMethodName("get", "value"));
         assertEquals("setValue", exCOParser.generateMethodName("set", "value"));
         assertEquals("getPositionVector", exCOParser.generateMethodName("get", "positionVector"));
@@ -63,6 +63,8 @@ class ObjectClassModelParserTest {
 
     @Test
     void testPhysicalEntityFields() {
+        assertEquals("HLAobjectRoot.PhysicalEntity", physicalEntityParser.getFomClassName());
+
         Field nameField = physicalEntityParser.getFieldForFomElement("name");
         Field statusField = physicalEntityParser.getFieldForFomElement("status");
         Field typeField = physicalEntityParser.getFieldForFomElement("type");
@@ -73,7 +75,6 @@ class ObjectClassModelParserTest {
 
         Set<String> publishableAttributes = physicalEntityParser.getPublishableAttributeNames();
         Set<String> subscribableAttributes = physicalEntityParser.getSubscribableAttributeNames();
-        assertEquals("HLAobjectRoot.PhysicalEntity", physicalEntityParser.getFomClassName());
         assertTrue(publishableAttributes.contains("name"));
         assertTrue(subscribableAttributes.contains("status"));
         assertTrue(publishableAttributes.contains("type"));

--- a/src/test/java/org/see/skf/runtime/ObjectClassModelParserTest.java
+++ b/src/test/java/org/see/skf/runtime/ObjectClassModelParserTest.java
@@ -3,6 +3,7 @@ package org.see.skf.runtime;
 import org.junit.jupiter.api.Test;
 import org.see.skf.annotations.Attribute;
 import org.see.skf.annotations.ObjectClass;
+import org.see.skf.util.encoding.HLAinteger16BECoder;
 import org.see.skf.util.models.ExecutionConfiguration;
 import org.see.skf.util.encoding.HLAfloat64LECoder;
 import org.see.skf.util.encoding.HLAunicodeStringCoder;
@@ -21,6 +22,7 @@ class ObjectClassModelParserTest {
     final ObjectClassModelParser physicalEntityParser = new ObjectClassModelParser(PhysicalEntity.class);
     final ObjectClassModelParser dynamicalEntityParser = new ObjectClassModelParser(DynamicalEntity.class);
     final ObjectClassModelParser roverParser = new ObjectClassModelParser(Rover.class);
+    final ObjectClassModelParser transportRoverParser = new ObjectClassModelParser(TransportRover.class);
 
     @Test
     void testBasicMetadata() {
@@ -114,7 +116,77 @@ class ObjectClassModelParserTest {
         assertEquals(ScopeLevel.SUBSCRIBE, dynamicalEntityParser.getAttributeAccessLevel("status"));
         assertEquals(ScopeLevel.PUBLISH_SUBSCRIBE, dynamicalEntityParser.getAttributeAccessLevel("type"));
         assertEquals(ScopeLevel.PUBLISH, dynamicalEntityParser.getAttributeAccessLevel("mass"));
-        assertEquals(ScopeLevel.NONE, dynamicalEntityParser.getAttributeAccessLevel("massRate"));
+        assertEquals(ScopeLevel.NONE, dynamicalEntityParser.getAttributeAccessLevel("mass_rate"));
+    }
+
+    @Test
+    void testRover() {
+        Field nameField = roverParser.getFieldForFomElement("name");
+        Field statusField = roverParser.getFieldForFomElement("status");
+        Field typeField = roverParser.getFieldForFomElement("type");
+        Field massField = roverParser.getFieldForFomElement("mass");
+        Field massRateField = roverParser.getFieldForFomElement("mass_rate");
+
+        assertNotNull(nameField);
+        assertNotNull(statusField);
+        assertNotNull(typeField);
+        assertNotNull(massField);
+        assertNotNull(massRateField);
+
+        Set<String> publishableAttributes = roverParser.getPublishableAttributeNames();
+        Set<String> subscribableAttributes = roverParser.getSubscribableAttributeNames();
+        assertEquals("HLAobjectRoot.PhysicalEntity.DynamicalEntity", roverParser.getFomClassName());
+        assertTrue(publishableAttributes.contains("name"));
+        assertTrue(subscribableAttributes.contains("status"));
+        assertTrue(publishableAttributes.contains("type"));
+        assertTrue(subscribableAttributes.contains("type"));
+        assertTrue(publishableAttributes.contains("mass"));
+        assertTrue(publishableAttributes.contains("mass"));
+        assertFalse(publishableAttributes.contains("mass_rate"));
+        assertFalse(subscribableAttributes.contains("mass_rate"));
+
+        assertEquals(ScopeLevel.PUBLISH, roverParser.getAttributeAccessLevel("name"));
+        assertEquals(ScopeLevel.SUBSCRIBE, roverParser.getAttributeAccessLevel("status"));
+        assertEquals(ScopeLevel.PUBLISH_SUBSCRIBE, roverParser.getAttributeAccessLevel("type"));
+        assertEquals(ScopeLevel.PUBLISH, roverParser.getAttributeAccessLevel("mass"));
+        assertEquals(ScopeLevel.NONE, roverParser.getAttributeAccessLevel("mass_rate"));
+    }
+
+    @Test
+    void testTransportRover() {
+        Field nameField = transportRoverParser.getFieldForFomElement("name");
+        Field statusField = transportRoverParser.getFieldForFomElement("status");
+        Field typeField = transportRoverParser.getFieldForFomElement("type");
+        Field massField = transportRoverParser.getFieldForFomElement("mass");
+        Field massRateField = transportRoverParser.getFieldForFomElement("mass_rate");
+        Field onboardCargoField = transportRoverParser.getFieldForFomElement("onboard_cargo");
+
+        assertNotNull(nameField);
+        assertNotNull(statusField);
+        assertNotNull(typeField);
+        assertNotNull(massField);
+        assertNotNull(massRateField);
+        assertNotNull(onboardCargoField);
+
+        Set<String> publishableAttributes = transportRoverParser.getPublishableAttributeNames();
+        Set<String> subscribableAttributes = transportRoverParser.getSubscribableAttributeNames();
+        assertEquals("HLAobjectRoot.PhysicalEntity.DynamicalEntity", roverParser.getFomClassName());
+        assertTrue(publishableAttributes.contains("name"));
+        assertTrue(subscribableAttributes.contains("status"));
+        assertTrue(publishableAttributes.contains("type"));
+        assertTrue(subscribableAttributes.contains("type"));
+        assertTrue(publishableAttributes.contains("mass"));
+        assertTrue(publishableAttributes.contains("mass"));
+        assertFalse(publishableAttributes.contains("mass_rate"));
+        assertFalse(subscribableAttributes.contains("mass_rate"));
+        assertTrue(publishableAttributes.contains("onboard_cargo"));
+
+        assertEquals(ScopeLevel.PUBLISH, transportRoverParser.getAttributeAccessLevel("name"));
+        assertEquals(ScopeLevel.SUBSCRIBE, transportRoverParser.getAttributeAccessLevel("status"));
+        assertEquals(ScopeLevel.PUBLISH_SUBSCRIBE, transportRoverParser.getAttributeAccessLevel("type"));
+        assertEquals(ScopeLevel.PUBLISH, transportRoverParser.getAttributeAccessLevel("mass"));
+        assertEquals(ScopeLevel.NONE, transportRoverParser.getAttributeAccessLevel("mass_rate"));
+        assertEquals(ScopeLevel.PUBLISH, transportRoverParser.getAttributeAccessLevel("onboard_cargo"));
     }
 
     // The following classes are meant to be representative of the SpaceFOM object hierarchy which is as follows:
@@ -193,5 +265,20 @@ class ObjectClassModelParserTest {
 
     static class Rover extends DynamicalEntity {
         public Rover() { super(); }
+    }
+
+    static class TransportRover extends Rover {
+        @Attribute(name = "onboard_cargo", coder = HLAinteger16BECoder.class, scope = ScopeLevel.PUBLISH)
+        private short onboardCargo;
+
+        public TransportRover() { super(); }
+
+        public short getOnboardCargo() {
+            return onboardCargo;
+        }
+
+        public void setOnboardCargo(short onboardCargo) {
+            this.onboardCargo = onboardCargo;
+        }
     }
 }

--- a/src/test/java/org/see/skf/runtime/ObjectClassModelParserTest.java
+++ b/src/test/java/org/see/skf/runtime/ObjectClassModelParserTest.java
@@ -17,148 +17,180 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ObjectClassModelParserTest {
-    final ObjectClassModelParser parser = new ObjectClassModelParser(ExecutionConfiguration.class);
+    final ObjectClassModelParser exCOParser = new ObjectClassModelParser(ExecutionConfiguration.class);
+    final ObjectClassModelParser physicalEntityParser = new ObjectClassModelParser(PhysicalEntity.class);
+    final ObjectClassModelParser dynamicalEntityParser = new ObjectClassModelParser(DynamicalEntity.class);
+    final ObjectClassModelParser roverParser = new ObjectClassModelParser(Rover.class);
 
     @Test
     void testMetadata() {
-        assertEquals("HLAobjectRoot.ExecutionConfiguration", parser.getFomClassName());
-        assertNotNull(parser.getFieldForFomElement("root_frame_name"));
-        assertNotNull(parser.getFieldForFomElement("least_common_time_step"));
-        assertNotNull(parser.getFieldForFomElement("scenario_time_epoch"));
+        assertEquals("HLAobjectRoot.ExecutionConfiguration", exCOParser.getFomClassName());
+        assertNotNull(exCOParser.getFieldForFomElement("root_frame_name"));
+        assertNotNull(exCOParser.getFieldForFomElement("least_common_time_step"));
+        assertNotNull(exCOParser.getFieldForFomElement("scenario_time_epoch"));
 
-        Field rootFrameName = parser.getFieldForFomElement("root_frame_name");
-        Field leastCommonTimeStep = parser.getFieldForFomElement("least_common_time_step");
-        Field scenarioTimeEpoch = parser.getFieldForFomElement("scenario_time_epoch");
-        assertNotNull(parser.getFieldGetter(rootFrameName));
-        assertNotNull(parser.getFieldSetter(rootFrameName));
-        assertNotNull(parser.getFieldGetter(leastCommonTimeStep));
-        assertNotNull(parser.getFieldSetter(leastCommonTimeStep));
-        assertNotNull(parser.getFieldGetter(scenarioTimeEpoch));
-        assertNotNull(parser.getFieldSetter(scenarioTimeEpoch));
+        Field rootFrameName = exCOParser.getFieldForFomElement("root_frame_name");
+        Field leastCommonTimeStep = exCOParser.getFieldForFomElement("least_common_time_step");
+        Field scenarioTimeEpoch = exCOParser.getFieldForFomElement("scenario_time_epoch");
+        assertNotNull(exCOParser.getFieldGetter(rootFrameName));
+        assertNotNull(exCOParser.getFieldSetter(rootFrameName));
+        assertNotNull(exCOParser.getFieldGetter(leastCommonTimeStep));
+        assertNotNull(exCOParser.getFieldSetter(leastCommonTimeStep));
+        assertNotNull(exCOParser.getFieldGetter(scenarioTimeEpoch));
+        assertNotNull(exCOParser.getFieldSetter(scenarioTimeEpoch));
 
-        assertNotNull(parser.getFieldCoder(rootFrameName));
-        assertNotNull(CoderCollection.query(parser.getFieldCoder(rootFrameName)));
-        assertNotNull(parser.getFieldCoder(leastCommonTimeStep));
-        assertNotNull(CoderCollection.query(parser.getFieldCoder(leastCommonTimeStep)));
-        assertNotNull(parser.getFieldCoder(scenarioTimeEpoch));
-        assertNotNull(CoderCollection.query(parser.getFieldCoder(scenarioTimeEpoch)));
+        assertNotNull(exCOParser.getFieldCoder(rootFrameName));
+        assertNotNull(CoderCollection.query(exCOParser.getFieldCoder(rootFrameName)));
+        assertNotNull(exCOParser.getFieldCoder(leastCommonTimeStep));
+        assertNotNull(CoderCollection.query(exCOParser.getFieldCoder(leastCommonTimeStep)));
+        assertNotNull(exCOParser.getFieldCoder(scenarioTimeEpoch));
+        assertNotNull(CoderCollection.query(exCOParser.getFieldCoder(scenarioTimeEpoch)));
 
-        assertEquals(ScopeLevel.SUBSCRIBE, parser.getAttributeAccessLevel("root_frame_name"));
-        assertEquals(ScopeLevel.SUBSCRIBE, parser.getAttributeAccessLevel("least_common_time_step"));
-        assertEquals(ScopeLevel.SUBSCRIBE, parser.getAttributeAccessLevel("scenario_time_epoch"));
+        assertEquals(ScopeLevel.SUBSCRIBE, exCOParser.getAttributeAccessLevel("root_frame_name"));
+        assertEquals(ScopeLevel.SUBSCRIBE, exCOParser.getAttributeAccessLevel("least_common_time_step"));
+        assertEquals(ScopeLevel.SUBSCRIBE, exCOParser.getAttributeAccessLevel("scenario_time_epoch"));
     }
 
     @Test
     void testMethodGeneration() {
-        assertEquals("getValue", parser.generateMethodName("get", "value"));
-        assertEquals("setValue", parser.generateMethodName("set", "value"));
-        assertEquals("getPositionVector", parser.generateMethodName("get", "positionVector"));
-        assertEquals("setPositionVector", parser.generateMethodName("set", "positionVector"));
-        assertEquals("getPhysicalInterface", parser.generateMethodName("get", "physicalInterface"));
-        assertEquals("setPhysicalInterface", parser.generateMethodName("set", "physicalInterface"));
+        assertEquals("getValue", exCOParser.generateMethodName("get", "value"));
+        assertEquals("setValue", exCOParser.generateMethodName("set", "value"));
+        assertEquals("getPositionVector", exCOParser.generateMethodName("get", "positionVector"));
+        assertEquals("setPositionVector", exCOParser.generateMethodName("set", "positionVector"));
+        assertEquals("getPhysicalInterface", exCOParser.generateMethodName("get", "physicalInterface"));
+        assertEquals("setPhysicalInterface", exCOParser.generateMethodName("set", "physicalInterface"));
     }
 
     @Test
-    void testSubclassInheritsParentAttributes() {
-        ObjectClassModelParser subclassParser = new ObjectClassModelParser(TestChildObject.class);
+    void testPhysicalEntityFields() {
+        Field nameField = physicalEntityParser.getFieldForFomElement("name");
+        Field statusField = physicalEntityParser.getFieldForFomElement("status");
+        Field typeField = physicalEntityParser.getFieldForFomElement("type");
 
-        Set<String> publishableAttributes = subclassParser.getPublishableAttributeNames();
-        assertTrue(publishableAttributes.contains("parent_name"));
-        assertTrue(publishableAttributes.contains("shared_status"));
-        assertTrue(publishableAttributes.contains("child_mass"));
-        assertFalse(publishableAttributes.contains("parent_subscribe_only"));
+        assertNotNull(nameField);
+        assertNotNull(statusField);
+        assertNotNull(typeField);
 
-        Set<String> subscribableAttributes = subclassParser.getSubscribableAttributeNames();
-        assertTrue(subscribableAttributes.contains("parent_name"));
-        assertTrue(subscribableAttributes.contains("shared_status"));
-        assertTrue(subscribableAttributes.contains("child_mass"));
-        assertTrue(subscribableAttributes.contains("parent_subscribe_only"));
+        Set<String> publishableAttributes = physicalEntityParser.getPublishableAttributeNames();
+        Set<String> subscribableAttributes = physicalEntityParser.getSubscribableAttributeNames();
+        assertEquals("HLAobjectRoot.PhysicalEntity", physicalEntityParser.getFomClassName());
+        assertTrue(publishableAttributes.contains("name"));
+        assertTrue(subscribableAttributes.contains("status"));
+        assertTrue(publishableAttributes.contains("type"));
 
-        Field parentName = subclassParser.getFieldForFomElement("parent_name");
-        Field parentState = subclassParser.getFieldForFomElement("shared_status");
-        Field childMass = subclassParser.getFieldForFomElement("child_mass");
-        Field parentSubscribeOnly = subclassParser.getFieldForFomElement("parent_subscribe_only");
-
-        assertNotNull(parentName);
-        assertNotNull(parentState);
-        assertNotNull(childMass);
-        assertNotNull(parentSubscribeOnly);
-
-        assertEquals(TestParentObject.class, parentName.getDeclaringClass());
-        assertEquals(TestChildObject.class, parentState.getDeclaringClass());
-        assertEquals(TestChildObject.class, childMass.getDeclaringClass());
-
-        assertNotNull(subclassParser.getFieldGetter(parentName));
-        assertNotNull(subclassParser.getFieldSetter(parentName));
-        assertNotNull(subclassParser.getFieldGetter(parentState));
-        assertNotNull(subclassParser.getFieldSetter(parentState));
-
-        assertEquals(ScopeLevel.PUBLISH_SUBSCRIBE, subclassParser.getAttributeAccessLevel("parent_name"));
-        assertEquals(ScopeLevel.PUBLISH_SUBSCRIBE, subclassParser.getAttributeAccessLevel("shared_status"));
-        assertEquals(ScopeLevel.PUBLISH_SUBSCRIBE, subclassParser.getAttributeAccessLevel("child_mass"));
-        assertEquals(ScopeLevel.SUBSCRIBE, subclassParser.getAttributeAccessLevel("parent_subscribe_only"));
+        assertEquals(ScopeLevel.PUBLISH, physicalEntityParser.getAttributeAccessLevel("name"));
+        assertEquals(ScopeLevel.SUBSCRIBE, physicalEntityParser.getAttributeAccessLevel("status"));
+        assertEquals(ScopeLevel.PUBLISH_SUBSCRIBE, physicalEntityParser.getAttributeAccessLevel("type"));
     }
 
-    @ObjectClass(name = "HLAobjectRoot.TestParentObject")
-    public static class TestParentObject {
-        @Attribute(name = "parent_name", coder = HLAunicodeStringCoder.class)
-        private String parentName = "";
+    @Test
+    void testDynamicalEntityFields() {
+        Field nameField = dynamicalEntityParser.getFieldForFomElement("name");
+        Field statusField = dynamicalEntityParser.getFieldForFomElement("status");
+        Field typeField = dynamicalEntityParser.getFieldForFomElement("type");
+        Field massField = dynamicalEntityParser.getFieldForFomElement("mass");
+        Field massRateField = dynamicalEntityParser.getFieldForFomElement("mass_rate");
 
-        @Attribute(name = "shared_status", coder = HLAunicodeStringCoder.class)
-        private String sharedStatus = "";
+        assertNotNull(nameField);
+        assertNotNull(statusField);
+        assertNotNull(typeField);
+        assertNotNull(massField);
+        assertNotNull(massRateField);
 
-        @Attribute(name = "parent_subscribe_only", coder = HLAunicodeStringCoder.class, scope = ScopeLevel.SUBSCRIBE)
-        private String parentSubscribeOnly = "";
+        Set<String> publishableAttributes = dynamicalEntityParser.getPublishableAttributeNames();
+        Set<String> subscribableAttributes = dynamicalEntityParser.getSubscribableAttributeNames();
+        assertEquals("HLAobjectRoot.PhysicalEntity.DynamicalEntity", dynamicalEntityParser.getFomClassName());
+        assertTrue(publishableAttributes.contains("name"));
+        assertTrue(subscribableAttributes.contains("status"));
+        assertTrue(publishableAttributes.contains("type"));
+        assertTrue(subscribableAttributes.contains("type"));
+        assertTrue(publishableAttributes.contains("mass"));
+        assertTrue(publishableAttributes.contains("mass"));
+        assertFalse(publishableAttributes.contains("mass_rate"));
+        assertFalse(subscribableAttributes.contains("mass_rate"));
 
-        public String getParentName() {
-            return parentName;
+        assertEquals(ScopeLevel.PUBLISH, dynamicalEntityParser.getAttributeAccessLevel("name"));
+        assertEquals(ScopeLevel.SUBSCRIBE, dynamicalEntityParser.getAttributeAccessLevel("status"));
+        assertEquals(ScopeLevel.PUBLISH_SUBSCRIBE, dynamicalEntityParser.getAttributeAccessLevel("type"));
+        assertEquals(ScopeLevel.PUBLISH, dynamicalEntityParser.getAttributeAccessLevel("mass"));
+        assertEquals(ScopeLevel.NONE, dynamicalEntityParser.getAttributeAccessLevel("massRate"));
+    }
+
+    // The following classes are meant to be representative of the SpaceFOM object hierarchy which is as follows:
+    // HLAobjectRoot -> PhysicalEntity -> DynamicalEntity -> Rover (a custom addition for test purposes)
+    @ObjectClass(name = "HLAobjectRoot.PhysicalEntity")
+    static class PhysicalEntity {
+        @Attribute(name = "name", coder = HLAunicodeStringCoder.class, scope = ScopeLevel.PUBLISH)
+        private String name;
+
+        @Attribute(name = "status", coder = HLAunicodeStringCoder.class, scope = ScopeLevel.SUBSCRIBE)
+        private String status;
+
+        @Attribute(name = "type", coder = HLAunicodeStringCoder.class)
+        private String type;
+
+        public PhysicalEntity() {
+            this.name = "physical_entity_1";
+            this.type = "Vehicle";
+            this.status = "Dormant";
         }
 
-        public void setParentName(String parentName) {
-            this.parentName = parentName;
+        public String getName() {
+            return name;
         }
 
-        public String getSharedStatus() {
-            return sharedStatus;
+        public void setName(String name) {
+            this.name = name;
         }
 
-        public void setSharedStatus(String sharedStatus) {
-            this.sharedStatus = sharedStatus;
+        public String getStatus() {
+            return status;
         }
 
-        public String getParentSubscribeOnly() {
-            return parentSubscribeOnly;
+        public void setStatus(String status) {
+            this.status = status;
         }
 
-        public void setParentSubscribeOnly(String parentSubscribeOnly) {
-            this.parentSubscribeOnly = parentSubscribeOnly;
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
         }
     }
 
-    @ObjectClass(name = "HLAobjectRoot.TestParentObject.TestChildObject")
-    public static class TestChildObject extends TestParentObject {
-        @Attribute(name = "shared_status", coder = HLAunicodeStringCoder.class)
-        private String sharedStatus = "";
+    @ObjectClass(name = "HLAobjectRoot.PhysicalEntity.DynamicalEntity")
+    static class DynamicalEntity extends PhysicalEntity {
+        @Attribute(name = "mass", coder = HLAfloat64LECoder.class, scope = ScopeLevel.PUBLISH)
+        private double mass;
 
-        @Attribute(name = "child_mass", coder = HLAfloat64LECoder.class)
-        private Double childMass = 0.0;
+        @Attribute(name = "mass_rate", coder = HLAfloat64LECoder.class, scope = ScopeLevel.NONE)
+        private double massRate;
 
-        @Override
-        public String getSharedStatus() {
-            return sharedStatus;
+        public DynamicalEntity() {
+            this.mass = 0.0;
+            this.massRate = 0.0;
         }
 
-        @Override
-        public void setSharedStatus(String sharedStatus) {
-            this.sharedStatus = sharedStatus;
+        public Double getMass() {
+            return mass;
         }
 
-        public Double getChildMass() {
-            return childMass;
+        public void setMass(Double mass) {
+            this.mass = mass;
         }
 
-        public void setChildMass(Double childMass) {
-            this.childMass = childMass;
+        public double getMassRate() {
+            return massRate;
         }
+
+        public void setMassRate(double massRate) {
+            this.massRate = massRate;
+        }
+    }
+
+    static class Rover extends DynamicalEntity {
+        public Rover() { super(); }
     }
 }


### PR DESCRIPTION
## Summary
- walk the Java class hierarchy when parsing object class models so subclasses inherit annotated parent attributes
- make subclass redeclarations replace inherited attribute mappings and publish/subscribe scope cleanly
- add parser tests for inherited attributes and subclass overrides

## Validation
- mvn test
- mvn install -DskipTests
- rebuilt Baseplate example against org.see:skf:2.0.3-SNAPSHOT and validated parent class publishing
- confirmed inherited PhysicalEntity attributes are exposed from subclass, including state, name, and parent_reference_frame